### PR TITLE
fix(login): add --accept-disclaimer to get-auth-url call

### DIFF
--- a/skills/baidu-drive/scripts/login.sh
+++ b/skills/baidu-drive/scripts/login.sh
@@ -104,7 +104,7 @@ log_info "正在获取授权链接..."
 # 检查是否支持 --get-auth-url 参数
 if bdpan login --help 2>/dev/null | grep -q "get-auth-url"; then
     # 新版本，支持 --get-auth-url
-    AUTH_URL=$(bdpan login --get-auth-url 2>/dev/null || echo "")
+    AUTH_URL=$(bdpan login --get-auth-url --accept-disclaimer 2>/dev/null || echo "")
 
     if [ -z "$AUTH_URL" ]; then
         log_error "获取授权链接失败"


### PR DESCRIPTION
## Problem
`login.sh` in `baidu-drive` fails on first use with:
```
Error: 首次使用请添加 --accept-disclaimer 参数
```

## Root Cause
`bdpan login --get-auth-url` requires `--accept-disclaimer` on first run, but `login.sh` doesn't pass it.

## Fix
Add `--accept-disclaimer` flag to the `--get-auth-url` call (line 107).

## Note
The sister skill `baidu-wenku-aippt-personal` already includes this flag in its `login.sh`.