### PR TITLE
fix(baidu-drive): accept disclaimer during OOB login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,6 @@ jobs:
               echo "✅ $skill_name 结构检查通过"
             fi
           done
+
+      - name: Test baidu-drive login flow
+        run: bash tests/test-baidu-drive-login.sh

--- a/skills/baidu-drive/scripts/login.sh
+++ b/skills/baidu-drive/scripts/login.sh
@@ -156,7 +156,8 @@ echo ""
 
 # 提示用户输入授权码
 echo -n "请输入浏览器中显示的授权码 (32 位十六进制字符): "
-read -r AUTH_CODE
+read -r -s AUTH_CODE
+echo
 
 if [ -z "$AUTH_CODE" ]; then
     log_error "授权码不能为空"
@@ -166,7 +167,6 @@ fi
 # 校验授权码格式：32 位十六进制字符
 if ! echo "$AUTH_CODE" | grep -qE '^[a-fA-F0-9]{32}$'; then
     log_error "授权码格式不正确（应为 32 位十六进制字符，如: ca0ee3070f75d0246357e5c74d525bda）"
-    log_error "当前输入: ${AUTH_CODE}"
     log_error "请确认您复制的是完整的授权码"
     exit 1
 fi

--- a/skills/baidu-drive/scripts/login.sh
+++ b/skills/baidu-drive/scripts/login.sh
@@ -104,7 +104,7 @@ log_info "正在获取授权链接..."
 # 检查是否支持 --get-auth-url 参数
 if bdpan login --help 2>/dev/null | grep -q "get-auth-url"; then
     # 新版本，支持 --get-auth-url
-    AUTH_URL=$(bdpan login --get-auth-url 2>/dev/null || echo "")
+    AUTH_URL=$(bdpan login --get-auth-url --accept-disclaimer 2>/dev/null || echo "")
 
     if [ -z "$AUTH_URL" ]; then
         log_error "获取授权链接失败"
@@ -176,7 +176,7 @@ log_info "正在使用授权码完成登录..."
 
 # 通过 stdin 安全传递授权码，避免在 ps / /proc/PID/cmdline 中泄露
 if bdpan login --help 2>/dev/null | grep -q "set-code-stdin"; then
-    echo "$AUTH_CODE" | bdpan login --set-code-stdin
+    echo "$AUTH_CODE" | bdpan login --set-code-stdin --accept-disclaimer
 else
     unset AUTH_CODE
     log_error "当前 bdpan 版本不支持 --set-code-stdin（安全授权码传递）"

--- a/tests/fakes/bdpan
+++ b/tests/fakes/bdpan
@@ -20,7 +20,7 @@ case "${1:-}" in
                 ;;
             --get-auth-url)
                 echo "get:$*" >> "$TEST_LOG"
-                if [[ " $* " != *" --accept-disclaimer "* ]]; then
+                if [ "$#" -ne 3 ] || [ "${3:-}" != "--accept-disclaimer" ]; then
                     echo "Error: 首次使用请添加 --accept-disclaimer 参数" >&2
                     exit 1
                 fi
@@ -28,7 +28,7 @@ case "${1:-}" in
                 ;;
             --set-code-stdin)
                 echo "set:$*" >> "$TEST_LOG"
-                if [[ " $* " != *" --accept-disclaimer "* ]]; then
+                if [ "$#" -ne 3 ] || [ "${3:-}" != "--accept-disclaimer" ]; then
                     echo "Error: 首次使用请添加 --accept-disclaimer 参数" >&2
                     exit 1
                 fi

--- a/tests/fakes/bdpan
+++ b/tests/fakes/bdpan
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eu
+
+case "${1:-}" in
+    version)
+        echo "bdpan: test"
+        ;;
+    whoami)
+        if [ -f "$TEST_STATE" ]; then
+            echo "认证状态: 已登录"
+        else
+            echo "⚠ 未登录"
+        fi
+        ;;
+    login)
+        case "${2:-}" in
+            --help)
+                echo "login supports --get-auth-url and --set-code-stdin"
+                ;;
+            --get-auth-url)
+                echo "get:$*" >> "$TEST_LOG"
+                if [[ " $* " != *" --accept-disclaimer "* ]]; then
+                    echo "Error: 首次使用请添加 --accept-disclaimer 参数" >&2
+                    exit 1
+                fi
+                echo "https://openapi.baidu.com/oauth/test"
+                ;;
+            --set-code-stdin)
+                echo "set:$*" >> "$TEST_LOG"
+                if [[ " $* " != *" --accept-disclaimer "* ]]; then
+                    echo "Error: 首次使用请添加 --accept-disclaimer 参数" >&2
+                    exit 1
+                fi
+                read -r code
+                if ! [[ "$code" =~ ^[a-fA-F0-9]{32}$ ]]; then
+                    echo "invalid authorization code" >&2
+                    exit 1
+                fi
+                : > "$TEST_STATE"
+                ;;
+            *)
+                echo "unexpected login arguments: $*" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "unexpected command: $*" >&2
+        exit 1
+        ;;
+esac

--- a/tests/test-baidu-drive-login.sh
+++ b/tests/test-baidu-drive-login.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+login_script="$test_root/login.sh"
+sed 's/\r$//' "$repo_root/skills/baidu-drive/scripts/login.sh" > "$login_script"
+
+mkdir -p "$test_root/bin"
+cp "$repo_root/tests/fakes/bdpan" "$test_root/bin/bdpan"
+chmod +x "$test_root/bin/bdpan"
+
+export TEST_STATE="$test_root/logged-in"
+export TEST_LOG="$test_root/calls.log"
+
+auth_code="0123456789abcdef0123456789abcdef"
+if ! output="$(
+    printf 'y%s\n' "$auth_code" |
+        PATH="$test_root/bin:$PATH" bash "$login_script" 2>&1
+)"; then
+    printf '%s\n' "$output"
+    echo "FAIL: login script exited unsuccessfully" >&2
+    exit 1
+fi
+
+printf '%s\n' "$output" | grep -Fq "https://openapi.baidu.com/oauth/test"
+grep -Fq "get:login --get-auth-url --accept-disclaimer" "$TEST_LOG"
+grep -Fq "set:login --set-code-stdin --accept-disclaimer" "$TEST_LOG"
+test -f "$TEST_STATE"
+
+echo "PASS: both login subcommands accept the disclaimer without exposing the authorization code"

--- a/tests/test-baidu-drive-login.sh
+++ b/tests/test-baidu-drive-login.sh
@@ -27,8 +27,30 @@ if ! output="$(
 fi
 
 printf '%s\n' "$output" | grep -Fq "https://openapi.baidu.com/oauth/test"
-grep -Fq "get:login --get-auth-url --accept-disclaimer" "$TEST_LOG"
-grep -Fq "set:login --set-code-stdin --accept-disclaimer" "$TEST_LOG"
+grep -Fxq "get:login --get-auth-url --accept-disclaimer" "$TEST_LOG"
+grep -Fxq "set:login --set-code-stdin --accept-disclaimer" "$TEST_LOG"
 test -f "$TEST_STATE"
 
-echo "PASS: both login subcommands accept the disclaimer without exposing the authorization code"
+if printf '%s\n' "$output" | grep -Fq "$auth_code" ||
+    grep -Fq "$auth_code" "$TEST_LOG"; then
+    echo "FAIL: authorization code was exposed in output or command arguments" >&2
+    exit 1
+fi
+
+rm -f "$TEST_STATE"
+: > "$TEST_LOG"
+invalid_code="${auth_code}x"
+if invalid_output="$(
+    printf 'y%s\n' "$invalid_code" |
+        PATH="$test_root/bin:$PATH" bash "$login_script" 2>&1
+)"; then
+    echo "FAIL: malformed authorization code was accepted" >&2
+    exit 1
+fi
+if printf '%s\n' "$invalid_output" | grep -Fq "$invalid_code" ||
+    grep -Fq "$invalid_code" "$TEST_LOG"; then
+    echo "FAIL: malformed authorization code was exposed in output or command arguments" >&2
+    exit 1
+fi
+
+echo "PASS: login commands accept the disclaimer and authorization codes stay secret"


### PR DESCRIPTION
## 改动说明

修复 `baidu-drive` Skill 首次进行 OOB 登录时无法获取授权链接的问题。

- 为 `bdpan login --get-auth-url` 和 `bdpan login --set-code-stdin` 传入 `--accept-disclaimer`。bdpan CLI 3.8.4 在首次使用时要求显式接受免责声明；旧脚本隐藏了该命令的标准错误，因此最终只报告“获取授权链接失败”。
- 授权码改为静默读取，格式错误时不再记录原始输入；授权码仍仅通过标准输入传递给 `--set-code-stdin`。
- 添加隔离的伪 bdpan 回归测试，精确验证两个子命令的参数，并验证有效和无效授权码均不会进入输出或命令参数日志。
- 将回归测试接入现有 CI。

## 改动类型

- [ ] 新功能 (feat)
- [x] Bug 修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码重构 (refactor)
- [x] 测试 (test)
- [ ] 其他 (chore)

## 关联 Issue

Closes #44

Related: #38

## 测试方式

1. `bash tests/test-baidu-drive-login.sh`
2. 对 `login.sh`、测试脚本和伪 bdpan 执行 `bash -n`
3. `make list`
4. `git diff upstream/main...HEAD --check`

## 检查清单

- [x] 代码已自测通过
- [x] 相关文档无需更新
- [x] Commit 消息符合 Conventional Commits 规范
- [x] 不含敏感信息（Token、密码、密钥等）
